### PR TITLE
Updating healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,10 @@ See [Divo GitHub](https://github.com/smartcitiesdata/divo) or [Divo Hex Document
 See [Pulsar Dockerhub](https://hub.docker.com/r/apachepulsar/pulsar) for further documentation
 on using and configuring the features of the container image itself.
 See [Pulsar source](https://pulsar.apache.org/) for the full codebase behind Pulsar
+
+### Health Check
+Contrary to obvious wisdom, the health check for the service does _not_ base itself on the return of the Pulsar Admin APIs
+`/brokers/health` endpoint. Through use of the tool, certain functionality of the cluster was found to still not be ready to
+receive client requests, such as trying to write to the default tenant/namespace. As a result, the health check has been rewritten
+to ensure the default tenant/namespace is ready to receive read and write requests before the container is judged to be ready
+as a standin for a fully-functional system.

--- a/lib/divo_pulsar.ex
+++ b/lib/divo_pulsar.ex
@@ -37,7 +37,7 @@ defmodule DivoPulsar do
         healthcheck: %{
           test: [
             "CMD-SHELL",
-            "curl http://localhost:8080/admin/v2/brokers/health | grep 'ok' || exit 1"
+            "curl -I http://localhost:8080/admin/v2/namespaces/public/default | grep '200' || exit 1"
           ],
           interval: "5s",
           timeout: "10s",

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule DivoPulsar.MixProject do
   def project() do
     [
       app: :divo_pulsar,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/divo_pulsar_test.exs
+++ b/test/divo_pulsar_test.exs
@@ -11,7 +11,7 @@ defmodule DivoPulsarTest do
           healthcheck: %{
             test: [
               "CMD-SHELL",
-              "curl http://localhost:8080/admin/v2/brokers/health | grep 'ok' || exit 1"
+              "curl -I http://localhost:8080/admin/v2/namespaces/public/default | grep '200' || exit 1"
             ],
             interval: "5s",
             timeout: "10s",
@@ -34,7 +34,7 @@ defmodule DivoPulsarTest do
           healthcheck: %{
             test: [
               "CMD-SHELL",
-              "curl http://localhost:8080/admin/v2/brokers/health | grep 'ok' || exit 1"
+              "curl -I http://localhost:8080/admin/v2/namespaces/public/default | grep '200' || exit 1"
             ],
             interval: "5s",
             timeout: "10s",


### PR DESCRIPTION
Making health check determine readiness of required components like the default tenant/namespace for reading and writing topics.